### PR TITLE
dev(narugo): now it supports python3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,104 @@
+name: Code Test
+
+on:
+  - push
+
+jobs:
+  unittest:
+    name: Code test
+    runs-on: ${{ matrix.os }}
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - 'ubuntu-latest'
+          - 'windows-latest'
+          - 'macos-latest'
+        python-version:
+          - '3.7'
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
+
+    steps:
+      - name: Get system version for Linux
+        if: ${{ contains(matrix.os, 'ubuntu') }}
+        shell: bash
+        run: |
+          echo "OS_NAME=Linux" >> $GITHUB_ENV
+          echo "IS_WIN=" >> $GITHUB_ENV
+          echo "IS_MAC=" >> $GITHUB_ENV
+      - name: Get system version for Windows
+        if: ${{ contains(matrix.os, 'windows') }}
+        shell: bash
+        run: |
+          echo "OS_NAME=Windows" >> $GITHUB_ENV
+          echo "IS_WIN=1" >> $GITHUB_ENV
+          echo "IS_MAC=" >> $GITHUB_ENV
+      - name: Get system version for MacOS
+        if: ${{ contains(matrix.os, 'macos') }}
+        shell: bash
+        run: |
+          echo "OS_NAME=MacOS" >> $GITHUB_ENV
+          echo "IS_WIN=" >> $GITHUB_ENV
+          echo "IS_MAC=1" >> $GITHUB_ENV
+      - name: Set environment for Cpython
+        if: ${{ !contains(matrix.python-version, 'pypy') }}
+        shell: bash
+        run: |
+          echo "IS_PYPY=" >> $GITHUB_ENV
+      - name: Set environment for PyPy
+        if: ${{ contains(matrix.python-version, 'pypy') }}
+        shell: bash
+        run: |
+          echo "IS_PYPY=1" >> $GITHUB_ENV
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 20
+          submodules: 'recursive'
+      - name: Set up system dependences on Linux
+        if: ${{ env.OS_NAME == 'Linux' }}
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y tree cloc wget curl make zip
+          sudo apt-get install -y git-lfs
+      - name: Set up system dependences on Windows
+        if: ${{ env.OS_NAME == 'Windows' }}
+        shell: bash
+        run: |
+          choco install tree cloc wget curl make zip
+      - name: Set up system dependences on MacOS
+        if: ${{ env.OS_NAME == 'MacOS' }}
+        run: |
+          brew install tree cloc wget curl make zip
+      - name: Set up python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-test.txt
+      - name: Test the basic environment
+        shell: bash
+        run: |
+          python -V
+          pip --version
+          pip list
+          tree .
+          cloc sankaku
+          cloc tests
+      - name: Run unittest
+        env:
+          CI: 'true'
+          LOGIN: ${{ secrets.UNITTEST_USERNAME }}
+          PASSWORD: ${{ secrets.UNITTEST_PASSWORD }}
+        shell: bash
+        run: |
+          pytest tests -sv --cov=sankaku --cov-report term-missing

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,9 @@ build/
 
 # mkdocs
 /site
+
+.python-version
+.env
+.coverage
+/test_*.py
+/venv*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include README.md
+include MANIFEST.in
+include requirements.txt
+include requirements-*.txt

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Source code: https://github.com/zerex290/sankaku
 
 ## Requirements
 
-- Python 3.11+
+- Python 3.7+
 - aiohttp
 - pydantic
 - loguru

--- a/requirements-socks.txt
+++ b/requirements-socks.txt
@@ -1,0 +1,1 @@
+aiohttp-socks

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,7 @@
+pytest~=7.3.1
+pytest-asyncio~=0.21.0
+pytest-cov~=4.0.0
+pytest-trio~=0.8.0
+pytest-twisted~=1.14.0
+anyio~=3.6.2
+twisted~=22.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aiohttp
 pydantic
 loguru
+typing_extensions; python_version < '3.9'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp
 pydantic
 loguru
+aiohttp-retry
 typing_extensions; python_version < '3.9'

--- a/sankaku/clients/abc.py
+++ b/sankaku/clients/abc.py
@@ -1,19 +1,19 @@
 from abc import ABC, abstractmethod
-from typing import Optional, Self
+from typing import Optional
 
 from sankaku.models.http import ClientResponse
-
 
 __all__ = ["ABCHttpClient", "ABCClient"]
 
 
 class ABCHttpClient(ABC):
     """Abstract client for handling http requests."""
+
     @abstractmethod
     def __init__(self, *args, **kwargs) -> None:
         pass
 
-    async def __aenter__(self) -> Self:
+    async def __aenter__(self):
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
@@ -34,16 +34,17 @@ class ABCHttpClient(ABC):
 
 class ABCClient(ABC):
     """Abstract Sankaku client."""
+
     @abstractmethod
     def __init__(self, *args, **kwargs) -> None:
         pass
 
     @abstractmethod
     async def login(
-        self,
-        *,
-        access_token: Optional[str] = None,
-        login: Optional[str] = None,
-        password: Optional[str] = None
+            self,
+            *,
+            access_token: Optional[str] = None,
+            login: Optional[str] = None,
+            password: Optional[str] = None
     ) -> None:
         """Login into sankakucomplex.com via access token or credentials."""

--- a/sankaku/constants.py
+++ b/sankaku/constants.py
@@ -36,6 +36,8 @@ BASE_RPM = 180
 BASE_PAGE_NUMBER = 1
 BASE_PAGE_LIMIT = 40
 
+BASE_RETRIES = 3
+
 PAGE_ALLOWED_ERRORS = [
     "snackbar__anonymous-recommendations-limit-reached",
     "snackbar__account_offset-forbidden"

--- a/sankaku/constants.py
+++ b/sankaku/constants.py
@@ -1,8 +1,9 @@
 """Necessary constants such as hardcoded headers, API urls and endpoints,
 default values of parameters etc.
 """
+from typing import Dict
 
-HEADERS: dict[str, str] = {
+HEADERS: Dict[str, str] = {
     "user-agent": (
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
         "(KHTML, like Gecko) Chrome/94.0.4606.85 YaBrowser/21.11.0.1996 "
@@ -13,7 +14,6 @@ HEADERS: dict[str, str] = {
     "accept-encoding": "gzip, deflate, br",
     "host": "capi-v2.sankakucomplex.com"
 }
-
 
 BASE_URL = "https://login.sankakucomplex.com"
 API_URL = "https://capi-v2.sankakucomplex.com"
@@ -30,7 +30,6 @@ PROFILE_URL = f"{USER_URL}/me"
 # Not fully completed urls for usage with str.format()
 COMMENT_URL = f"{POST_URL}/{{post_id}}/comments"
 RELATED_BOOK_URL = f"{API_URL}/post/{{post_id}}/pools"
-
 
 BASE_RPS = 3
 BASE_RPM = 180

--- a/sankaku/errors.py
+++ b/sankaku/errors.py
@@ -1,6 +1,5 @@
 from typing import Optional
 
-
 __all__ = [
     "SankakuError",
     "RateLimitError",
@@ -41,6 +40,7 @@ class VideoDurationError(SankakuError):
 
 class SankakuServerError(SankakuError):
     """Error class for parametrized exceptions."""
+
     def __init__(
             self,
             status: Optional[int],

--- a/sankaku/models/books.py
+++ b/sankaku/models/books.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
-from typing import Optional
 from datetime import datetime
+from typing import Optional, List
 
 from pydantic import BaseModel
 
 from sankaku import types
-from .users import Author
-from .tags import PostTag
 from .posts import Post
-
+from .tags import PostTag
+from .users import Author
 
 __all__ = ["PageBook", "Book"]
 
@@ -50,13 +49,13 @@ class PageBook(BaseModel):
     vote_count: int
     total_score: int
     comment_count: Optional[int]
-    tags: list[PostTag]
-    post_tags: list[PostTag]
-    artist_tags: list[PostTag]
-    genre_tags: list[PostTag]
+    tags: List[PostTag]
+    post_tags: List[PostTag]
+    artist_tags: List[PostTag]
+    genre_tags: List[PostTag]
     is_favorited: bool
     user_vote: Optional[int]
-    posts: list[Post]
+    posts: List[Post]
     file_url: Optional[str]
     sample_url: Optional[str]
     preview_url: Optional[str]
@@ -76,6 +75,6 @@ class PageBook(BaseModel):
 
 class Book(PageBook):
     """Model that describes specific book."""
-    child_pools: Optional[list[PageBook]]
+    child_pools: Optional[List[PageBook]]
     flagged_by_user: bool
     prem_post_count: int

--- a/sankaku/models/http.py
+++ b/sankaku/models/http.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from typing import Any
 
-
 __all__ = ["ClientResponse"]
 
 

--- a/sankaku/models/pages.py
+++ b/sankaku/models/pages.py
@@ -1,9 +1,7 @@
-from typing import Generic, TypeVar
 from dataclasses import dataclass
-
+from typing import Generic, TypeVar, List
 
 __all__ = ["Page"]
-
 
 _T = TypeVar("_T")
 
@@ -12,4 +10,4 @@ _T = TypeVar("_T")
 class Page(Generic[_T]):
     """Model that describes page containing content with specific type."""
     number: int
-    items: list[_T]
+    items: List[_T]

--- a/sankaku/models/posts.py
+++ b/sankaku/models/posts.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from typing import Optional
 from datetime import datetime
+from typing import Optional, List
 
 from pydantic import BaseModel, Field, validator
 
@@ -9,7 +9,6 @@ from sankaku import types
 from sankaku.utils import convert_ts_to_datetime
 from .tags import PostTag
 from .users import Author
-
 
 __all__ = ["Comment", "Post", "AIPost"]
 
@@ -40,20 +39,19 @@ class BasePost(BaseModel):
     extension: Optional[str] = Field(alias="file_type")
     generation_directives: Optional[GenerationDirectives]
     md5: str
-    tags: list[PostTag]
+    tags: List[PostTag]
 
     @property
     def file_type(self) -> Optional[types.FileType]:
         """Get type of the file."""
-        match self.extension:
-            case "png" | "jpeg" | "webp":
-                return types.FileType.IMAGE
-            case "webm" | "mp4":
-                return types.FileType.VIDEO
-            case "gif":
-                return types.FileType.GIF
-            case _:
-                return None
+        if self.extension in ('png', 'jpeg', 'webp'):
+            return types.FileType.IMAGE
+        elif self.extension in ('webm', 'mp4'):
+            return types.FileType.VIDEO
+        elif self.extension in ('gif',):
+            return types.FileType.GIF
+        else:
+            return None
 
     # Validators
     _normalize_datetime = (
@@ -75,7 +73,7 @@ class Comment(BaseModel):
     body: str
     score: int
     parent_id: Optional[int]
-    children: list[Comment]
+    children: List[Comment]
     deleted: bool
     deleted_by: dict  # Seen only empty dictionaries so IDK real type
     updated_at: Optional[datetime]

--- a/sankaku/models/tags.py
+++ b/sankaku/models/tags.py
@@ -1,12 +1,11 @@
-from typing import Optional
 from datetime import datetime
+from typing import Optional, List
 
 from pydantic import BaseModel, Field, validator
 
 from sankaku import types
 from sankaku.utils import convert_ts_to_datetime
 from .users import Author
-
 
 __all__ = ["PostTag", "PageTag", "Wiki", "WikiTag"]
 
@@ -41,7 +40,7 @@ class PostTag(BaseTag, TagMixin):
 class NestedTag(BaseTag):
     """Model that describes tags with specific relation to certain tag on tag page."""
     post_count: int = Field(alias="postCount")
-    cached_related: Optional[list[int]] = Field(alias="cachedRelated")
+    cached_related: Optional[List[int]] = Field(alias="cachedRelated")
     cached_related_expires_on: datetime = Field(alias="cachedRelatedExpiresOn")
     type: types.TagType = Field(alias="tagType")
     name_en: str = Field(alias="nameEn")
@@ -52,8 +51,8 @@ class NestedTag(BaseTag):
     popularity_safe: Optional[float] = Field(alias="scTagPopularitySafe")
     quality_ero: Optional[float] = Field(alias="scTagQualityEro")
     quality_safe: Optional[float] = Field(alias="scTagQualitySafe")
-    parent_tags: Optional[list[int]] = Field(alias="parentTags")
-    child_tags: Optional[list[int]] = Field(alias="childTags")
+    parent_tags: Optional[List[int]] = Field(alias="parentTags")
+    child_tags: Optional[List[int]] = Field(alias="childTags")
     pool_count: int = Field(alias="poolCount")
     premium_post_count: int = Field(alias="premPostCount")
     non_premium_post_count: int = Field(alias="nonPremPostCount")
@@ -68,7 +67,7 @@ class NestedTag(BaseTag):
     version: Optional[int]
 
     @validator("cached_related", "parent_tags", "child_tags", pre=True)
-    def flatten(cls, v) -> Optional[list[int]]:  # noqa
+    def flatten(cls, v) -> Optional[List[int]]:  # noqa
         """Flatten nested lists into one."""
         if not v:
             return None
@@ -88,10 +87,10 @@ class Translations(BaseModel):
 
 class PageTag(PostTag):
     """Model that describes tags on tag page."""
-    translations: list[Translations]
-    related_tags: list[NestedTag]
-    child_tags: list[NestedTag]
-    parent_tags: list[NestedTag]
+    translations: List[Translations]
+    related_tags: List[NestedTag]
+    child_tags: List[NestedTag]
+    parent_tags: List[NestedTag]
 
 
 class Wiki(BaseModel):
@@ -114,10 +113,10 @@ class Wiki(BaseModel):
 
 class WikiTag(BaseTag, TagMixin):
     """Model that describes tag on wiki page."""
-    related_tags: list[PostTag]
-    child_tags: list[PostTag]
-    parent_tags: list[PostTag]
-    alias_tags: list[PostTag]
-    implied_tags: list[PostTag]
-    translations: list[Translations]
+    related_tags: List[PostTag]
+    child_tags: List[PostTag]
+    parent_tags: List[PostTag]
+    alias_tags: List[PostTag]
+    implied_tags: List[PostTag]
+    translations: List[Translations]
     wiki: Wiki

--- a/sankaku/models/users.py
+++ b/sankaku/models/users.py
@@ -1,10 +1,9 @@
 from datetime import datetime
-from typing import Optional
+from typing import Optional, List
 
 from pydantic import BaseModel, Field, validator
 
 from sankaku import types
-
 
 __all__ = ["Author", "User", "ExtendedUser"]
 
@@ -55,7 +54,7 @@ class User(BaseUser):
     post_vote_count: Optional[int] = None
     pool_vote_count: Optional[int] = None
     recommended_posts_for_user: Optional[int] = None
-    subscriptions: list[str] = []
+    subscriptions: List[str] = []
 
 
 class ExtendedUser(User):
@@ -69,11 +68,11 @@ class ExtendedUser(User):
     is_verified: bool
     verifications_count: int
     blacklist_is_hidden: bool
-    blacklisted_tags: list[str]
-    blacklisted: list[str]
+    blacklisted_tags: List[str]
+    blacklisted: List[str]
     mfa_method: int
 
     @validator("blacklisted_tags", pre=True)
-    def flatten_blacklisted_tags(cls, v) -> list[str]:  # noqa
+    def flatten_blacklisted_tags(cls, v) -> List[str]:  # noqa
         """Flatten nested lists into one."""
         return [tag[0] for tag in v]

--- a/sankaku/paginators/abc.py
+++ b/sankaku/paginators/abc.py
@@ -1,18 +1,16 @@
 from abc import ABC, abstractmethod
-from collections.abc import AsyncIterator
-from typing import Generic, TypeVar
+from typing import Generic, TypeVar, AsyncIterator
 
 from sankaku import errors, models as mdl
 
-
 __all__ = ["ABCPaginator"]
-
 
 _T = TypeVar("_T")
 
 
 class ABCPaginator(ABC, Generic[_T]):
     """Abstract paginator class."""
+
     @abstractmethod
     def __init__(self, *args, **kwargs) -> None:
         pass

--- a/sankaku/paginators/paginators.py
+++ b/sankaku/paginators/paginators.py
@@ -50,11 +50,11 @@ class Paginator(ABCPaginator[_T]):
         """Get paginator next page."""
         response = await self.http_client.get(self.url, params=self.params)
         json_ = response.json
-        if json_ == [] or json_ == {'data': []}:
+        if json_ == [] or (isinstance(json_, dict) and not json_.get("data")):
             raise errors.PaginatorLastPage(response.status, page=self.page_number)
         elif 'code' in json_ and 'errorId' in json_:
             raise errors.SankakuServerError(response.status, **response.json)
-        elif 'code' in json_:
+        elif 'code' in json_ and json_['code'] in const.PAGE_ALLOWED_ERRORS:
             raise errors.PaginatorLastPage(response.status, page=self.page_number)
         elif 'data' in json_:
             response.json = json_['data']

--- a/sankaku/paginators/paginators.py
+++ b/sankaku/paginators/paginators.py
@@ -52,10 +52,10 @@ class Paginator(ABCPaginator[_T]):
         json_ = response.json
         if json_ == [] or (isinstance(json_, dict) and not json_.get("data")):
             raise errors.PaginatorLastPage(response.status, page=self.page_number)
-        elif 'code' in json_ and 'errorId' in json_:
-            raise errors.SankakuServerError(response.status, **response.json)
         elif 'code' in json_ and json_['code'] in const.PAGE_ALLOWED_ERRORS:
             raise errors.PaginatorLastPage(response.status, page=self.page_number)
+        elif 'code' in json_ and 'errorId' in json_:
+            raise errors.SankakuServerError(response.status, **response.json)
         elif 'data' in json_:
             response.json = json_['data']
 

--- a/sankaku/typedefs.py
+++ b/sankaku/typedefs.py
@@ -1,6 +1,10 @@
 from dataclasses import dataclass
-from typing import TypedDict, Optional
+from typing import Optional
 
+try:
+    from typing import TypedDict
+except (ImportError, ModuleNotFoundError):
+    from typing_extensions import TypedDict
 
 __all__ = ["ValueRange", "Timestamp"]
 

--- a/sankaku/types.py
+++ b/sankaku/types.py
@@ -1,6 +1,5 @@
 from enum import Enum
 
-
 __all__ = [
     "Rating",
     "PostOrder",

--- a/setup.py
+++ b/setup.py
@@ -31,11 +31,15 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=["tests", "tests.*"]),
     license="MIT",
     classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.11",
+    python_requires=">=3.7",
     install_requires=requirements,  # this will change after you change requirements
     tests_require=group_requirements['test'],
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setuptools.setup(
     ],
     python_requires=">=3.7",
     install_requires=requirements,  # this will change after you change requirements
-    tests_require=group_requirements['test'],
 
     # you can install other requirements like `pip install sankaku[socks]`
     extras_require=group_requirements,

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,21 @@
+import os
+import re
+
 import setuptools
+
+
+def _load_req(file: str):
+    with open(file, 'r', encoding='utf-8') as f:
+        return [line.strip() for line in f.readlines() if line.strip()]
+
+
+requirements = _load_req('requirements.txt')
+
+_REQ_PATTERN = re.compile('^requirements-([a-zA-Z0-9_]+)\\.txt$')
+group_requirements = {
+    item.group(1): _load_req(item.group(0))
+    for item in [_REQ_PATTERN.fullmatch(reqpath) for reqpath in os.listdir()] if item
+}
 
 setuptools.setup(
     name="sankaku",
@@ -19,5 +36,9 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.11",
-    install_requires=["aiohttp", "pydantic", "loguru"]
+    install_requires=requirements,  # this will change after you change requirements
+    tests_require=group_requirements['test'],
+
+    # you can install other requirements like `pip install sankaku[socks]`
+    extras_require=group_requirements,
 )


### PR DESCRIPTION
Related to #2 

What is changed:

* Add support for python3.7~3.10 (I tested 3.7, 3.8 and 3.11 in my own environment, all 80 tests are passed)
* Add support for proxy in environment
  * If you are using http proxy, just set `HTTPS_PROXY` (attention that `aiohttp` does not detect `ALL_PROXY`)
  * If you are using socks proxy, just install `sankaku[socks]` and then set `ALL_PROXY`, `HTTP_PROXY`, `HTTPS_PROXY`
* Add requirements files and put their content into setup.py
* Add [unittest on github action](https://github.com/narugo1992/sankaku/actions/runs/5036836027)
* Add retries