### PR TITLE
dev(narugo): is_ai_beta is gone in new API

### DIFF
--- a/sankaku/models/users.py
+++ b/sankaku/models/users.py
@@ -44,7 +44,6 @@ class User(BaseUser):
     show_popup_version: int
     credits: int
     credits_subs: int
-    is_ai_beta: bool
 
     # The following fields can be missing in API json response
     last_logged_in_at: Optional[datetime] = None
@@ -56,6 +55,7 @@ class User(BaseUser):
     pool_vote_count: Optional[int] = None
     recommended_posts_for_user: Optional[int] = None
     subscriptions: List[str] = []
+    is_ai_beta: Optional[bool] = None
 
 
 class ExtendedUser(User):


### PR DESCRIPTION
This is the error occurred in the last few hours

```
Traceback (most recent call last):
  File "test_hair_color.py", line 167, in <module>
    asyncio.run(main(
  File "/usr/lib/python3.8/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "test_hair_color.py", line 35, in main
    await client.login(<hidden>)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/sankaku/clients/clients.py", line 92, in login
    await self._login_via_credentials(login, password)  # type: ignore[arg-type]
  File "/home/ubuntu/.local/lib/python3.8/site-packages/sankaku/clients/clients.py", line 48, in _login_via_credentials
    self._profile = mdl.ExtendedUser(**response.json["current_user"])
  File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for ExtendedUser
is_ai_beta
  field required (type=value_error.missing)
```

I found that is_ai_beta is gone in the new API. So I move this to the optional arguments.